### PR TITLE
Lesson 13 README.md: change to get_erc721_name

### DIFF
--- a/Draft/13-接口/README.md
+++ b/Draft/13-接口/README.md
@@ -103,7 +103,7 @@ def get_name(_token: address) -> String[50]:
 
 @view
 @external
-def get_name(_token: address) -> String[50]:
+def get_erc721_name(_token: address) -> String[50]:
 	return ERC721(_token).name()
 
 ```


### PR DESCRIPTION
Readme 的函数命名修改成和 examply.vy 里面一致的